### PR TITLE
fix: change name convention to camel case

### DIFF
--- a/rupring_macro/src/rule.rs
+++ b/rupring_macro/src/rule.rs
@@ -1,7 +1,7 @@
 pub(crate) fn make_route_name(function_name: &str) -> String {
     let mut route_name = String::new();
 
-    route_name.push_str(&format!("Route_{}", function_name));
+    route_name.push_str(&format!("Route{}", function_name.chars().next().unwrap().to_uppercase().chain(function_name.chars().skip(1)))));
 
     return route_name;
 }
@@ -9,7 +9,7 @@ pub(crate) fn make_route_name(function_name: &str) -> String {
 pub(crate) fn make_handler_name(function_name: &str) -> String {
     let mut handler_name = String::new();
 
-    handler_name.push_str(&format!("Handler_{}", function_name));
+    handler_name.push_str(&format!("Handler{}", function_name.chars().next().unwrap().to_uppercase().chain(function_name.chars().skip(1)))));
 
     return handler_name;
 }


### PR DESCRIPTION
## 설명

I follow tutorial, but i get an warning on this example

![스크린샷 2024-09-20 오전 9 35 31](https://github.com/user-attachments/assets/bca4d1b7-e887-4d83-802a-650b24538a34)
