### PR TITLE
[#183] swagger.json에서 기본 scheme 값 제거

### DIFF
--- a/rupring/src/swagger/json.rs
+++ b/rupring/src/swagger/json.rs
@@ -42,7 +42,7 @@ impl Default for SwaggerSchema {
             info: Default::default(),
             host: None,
             base_path: r#""#.to_string(),
-            schemes: vec!["http".to_string(), "https".to_string()],
+            schemes: vec![],
             tags: Default::default(),
             paths: Default::default(),
             definitions: Default::default(),


### PR DESCRIPTION
resolves: #183

## 설명
굳이 명시하지 않으면 http/https를 자동으로 현재 컨텍스트에 따라 맞추는데, 저렇게 명시하면 첫번째로 넣은 값이 기본값으로 박혀버려서 오히려 더 꼬임. 
그래서 그냥 값을 제거함