### PR TITLE
[#201] cookie - response 핸들링 구현

### DIFF
--- a/rupring/src/header.rs
+++ b/rupring/src/header.rs
@@ -12,6 +12,7 @@ pub const CONTENT_ENCODING: &'static str = "content-encoding";
 pub const USER_AGENT: &'static str = "user-agent";
 pub const HOST: &'static str = "host";
 pub const CONNECTION: &'static str = "connection";
+pub const SET_COOKIE: &'static str = "set-cookie";
 
 // response only headers
 pub const LOCATION: &'static str = "location";

--- a/rupring/src/response.rs
+++ b/rupring/src/response.rs
@@ -71,11 +71,25 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 
 #[derive(Debug, Clone, Default)]
+pub struct Cookie {
+    pub name: String,
+    pub value: String,
+    pub(crate) expires: Option<String>,
+    pub(crate) max_age: Option<String>,
+    pub(crate) domain: Option<String>,
+    pub(crate) path: Option<String>,
+    pub(crate) secure: Option<bool>,
+    pub(crate) http_only: Option<bool>,
+    pub(crate) same_site: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct Response {
     pub status: u16,
     pub body: Vec<u8>,
     pub headers: HashMap<HeaderName, String>,
     pub(crate) next: Option<Box<(Request, Response)>>,
+    pub(crate) set_cookies: Vec<Cookie>,
 }
 
 impl UnwindSafe for Response {}
@@ -92,6 +106,7 @@ impl Response {
             body: Vec::new(),
             headers: Default::default(),
             next: None,
+            set_cookies: Vec::new(),
         }
     }
 

--- a/rupring/src/response.rs
+++ b/rupring/src/response.rs
@@ -70,20 +70,27 @@ use crate::{header, meme, HeaderName, Request};
 use http_body_util::Full;
 use hyper::body::Bytes;
 
+/// HTTP cookie
 #[derive(Debug, Clone, Default)]
 pub struct Cookie {
     pub name: String,
     pub value: String,
-    pub(crate) expires: Option<String>,
-    pub(crate) max_age: Option<String>,
-    pub(crate) domain: Option<String>,
-    pub(crate) path: Option<String>,
-    pub(crate) secure: Option<bool>,
-    pub(crate) http_only: Option<bool>,
-    pub(crate) same_site: Option<String>,
+    pub expires: Option<String>,
+    pub max_age: Option<String>,
+    pub domain: Option<String>,
+    pub path: Option<String>,
+    pub secure: Option<bool>,
+    pub http_only: Option<bool>,
+    pub same_site: Option<String>,
 }
 
 impl Cookie {
+    /// Create a new cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar");
+    /// assert_eq!(cookie.name, "foo");
+    /// assert_eq!(cookie.value, "bar");
+    /// ```
     pub fn new(name: impl ToString, value: impl ToString) -> Self {
         Self {
             name: name.to_string(),
@@ -92,36 +99,71 @@ impl Cookie {
         }
     }
 
+    /// Set the expiration date of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").expires("Wed, 21 Oct 2015 07:28:00 GMT");
+    /// assert_eq!(cookie.expires.unwrap(), "Wed, 21 Oct 2015 07:28:00 GMT");
+    /// ```
     pub fn expires(mut self, expires: impl ToString) -> Self {
         self.expires = Some(expires.to_string());
         return self;
     }
 
+    /// Set the maximum age of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").max_age("3600");
+    /// assert_eq!(cookie.max_age.unwrap(), "3600");
+    /// ```
     pub fn max_age(mut self, max_age: impl ToString) -> Self {
         self.max_age = Some(max_age.to_string());
         return self;
     }
 
+    /// Set the domain of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").domain("example.com");
+    /// assert_eq!(cookie.domain.unwrap(), "example.com");
+    /// ```
     pub fn domain(mut self, domain: impl ToString) -> Self {
         self.domain = Some(domain.to_string());
         return self;
     }
 
+    /// Set the path of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").path("/path");
+    /// assert_eq!(cookie.path.unwrap(), "/path");
+    /// ```
     pub fn path(mut self, path: impl ToString) -> Self {
         self.path = Some(path.to_string());
         return self;
     }
 
+    /// Set the secure flag of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").secure(true);
+    /// assert_eq!(cookie.secure.unwrap(), true);
+    /// ```
     pub fn secure(mut self, secure: bool) -> Self {
         self.secure = Some(secure);
         return self;
     }
 
+    /// Set the http only flag of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").http_only(true);
+    /// assert_eq!(cookie.http_only.unwrap(), true);
+    /// ```
     pub fn http_only(mut self, http_only: bool) -> Self {
         self.http_only = Some(http_only);
         return self;
     }
 
+    /// Set the same site attribute of the cookie.
+    /// ```
+    /// let cookie = rupring::response::Cookie::new("foo", "bar").same_site("Strict");
+    /// assert_eq!(cookie.same_site.unwrap(), "Strict");
+    /// ```
     pub fn same_site(mut self, same_site: impl ToString) -> Self {
         self.same_site = Some(same_site.to_string());
         return self;

--- a/rupring/src/response.rs
+++ b/rupring/src/response.rs
@@ -254,7 +254,7 @@ impl Response {
     /// ```
     /// use rupring::HeaderName;
     /// let response = rupring::Response::new().header("content-type", "application/json".to_string());
-    /// assert_eq!(response.headers.get(&HeaderName::from_static("content-type")).unwrap(), &"application/json".to_string());
+    /// assert_eq!(response.headers.get(&HeaderName::from_static("content-type")).unwrap(), &vec!["application/json".to_string()]);
     pub fn header(mut self, name: &'static str, value: impl ToString) -> Self {
         if let Some(values) = self.headers.get_mut(&HeaderName::from_static(name)) {
             values.push(value.to_string());
@@ -271,9 +271,9 @@ impl Response {
     /// use rupring::HeaderName;
     /// use std::collections::HashMap;
     /// let mut headers = HashMap::new();
-    /// headers.insert(HeaderName::from_static("content-type"), "application/json".to_string());
+    /// headers.insert(HeaderName::from_static("content-type"), vec!["application/json".to_string()]);
     /// let response = rupring::Response::new().headers(headers);
-    /// assert_eq!(response.headers.get(&HeaderName::from_static("content-type")).unwrap(), &"application/json".to_string());
+    /// assert_eq!(response.headers.get(&HeaderName::from_static("content-type")).unwrap(), &vec!["application/json".to_string()]);
     pub fn headers(mut self, headers: HashMap<HeaderName, Vec<String>>) -> Self {
         self.headers = headers;
         return self;
@@ -284,7 +284,7 @@ impl Response {
     /// use rupring::HeaderName;
     /// use std::collections::HashMap;
     /// let response = rupring::Response::new().redirect("https://naver.com");
-    /// assert_eq!(response.headers.get(&HeaderName::from_static("location")).unwrap(), &"https://naver.com".to_string());
+    /// assert_eq!(response.headers.get(&HeaderName::from_static("location")).unwrap(), &vec!["https://naver.com".to_string()]);
     pub fn redirect(mut self, url: impl ToString) -> Self {
         if self.status < 300 || self.status > 308 {
             self.status = 302;

--- a/rupring_example/Cargo.toml
+++ b/rupring_example/Cargo.toml
@@ -6,7 +6,7 @@ default-run = "example"
 
 [dependencies]
 mockall = "0.13.1"
-rupring={ version = "0.12.2", path="../rupring", features=["full", "tls"] }
+rupring={ version = "0.12.2", path="../rupring", features=["full"] }
 serde = { version="1.0.193", features=["derive"] }
 
 [[bin]]

--- a/rupring_example/src/domains/root/controller.rs
+++ b/rupring_example/src/domains/root/controller.rs
@@ -1,3 +1,5 @@
+use rupring::response::Cookie;
+
 #[derive(Debug, Clone)]
 #[rupring::Controller(prefix=/, routes=[index, slow], tags=["root"])]
 pub struct RootController {}
@@ -12,8 +14,8 @@ pub fn index(request: rupring::Request) -> rupring::Response {
 
     rupring::Response::new()
         .text("123214")
-        .header(rupring::header::SET_COOKIE, "foo=bar")
-        .header(rupring::header::SET_COOKIE, "baz=qux")
+        .add_cookie(Cookie::new("name", "value").http_only(true).secure(true))
+        .add_cookie(Cookie::new("name2", "value2").http_only(true).secure(true))
 }
 
 #[rupring::Get(path = /slow)]

--- a/rupring_example/src/domains/root/controller.rs
+++ b/rupring_example/src/domains/root/controller.rs
@@ -10,7 +10,10 @@ pub fn index(request: rupring::Request) -> rupring::Response {
     let body = request.body;
     println!("body: {}", body);
 
-    rupring::Response::new().text("123214")
+    rupring::Response::new()
+        .text("123214")
+        .header(rupring::header::SET_COOKIE, "foo=bar")
+        .header(rupring::header::SET_COOKIE, "baz=qux")
 }
 
 #[rupring::Get(path = /slow)]


### PR DESCRIPTION
resolves: #201

## 설명
1. Response headers의 값을 단일 스칼라 문자열에서 문자열의 배열로 바꿈 => 같은 헤더 키값을 여러개 보낼 수 있음 
2. Response에 add_cookie 함수 추가