### PR TITLE
[#274] Response::header 오류케이스 제거

### DIFF
--- a/rupring/src/response.rs
+++ b/rupring/src/response.rs
@@ -358,17 +358,18 @@ impl Response {
     /// use rupring::HeaderName;
     /// let response = rupring::Response::new().header("content-type", "application/json".to_string());
     /// assert_eq!(response.headers.get(&HeaderName::from_static("content-type")).unwrap(), &vec!["application/json".to_string()]);
-    pub fn header(mut self, name: &'static str, value: impl ToString) -> Self {
-        if let Some(values) = self.headers.get_mut(&HeaderName::from_static(name)) {
-            // if content-type already exists, overwrite it.
-            if name == header::CONTENT_TYPE {
-                values.clear();
-            }
+    pub fn header(mut self, name: &str, value: impl ToString) -> Self {
+        if let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) {
+            if let Some(values) = self.headers.get_mut(&header_name) {
+                // if content-type already exists, overwrite it.
+                if header_name.as_str() == header::CONTENT_TYPE {
+                    values.clear();
+                }
 
-            values.push(value.to_string());
-        } else {
-            self.headers
-                .insert(HeaderName::from_static(name), vec![value.to_string()]);
+                values.push(value.to_string());
+            } else {
+                self.headers.insert(header_name, vec![value.to_string()]);
+            }
         }
 
         self

--- a/rupring_example/src/domains/users/controller.rs
+++ b/rupring_example/src/domains/users/controller.rs
@@ -82,7 +82,6 @@ pub fn update_user(
         Err(_) => return rupring::Response::new().status(400).text("bad request"),
     };
 
-
     let response = user_service.update_user(request);
 
     match response {
@@ -212,10 +211,8 @@ const SERVE_SSE_HTML: &str = r#"
 #[summary = "SSE 페이지"]
 pub fn serve_sse_page(request: rupring::Request) -> rupring::Response {
     rupring::Response::new()
-        .html(SERVE_SSE_HTML)
+        .html(SERVE_SSE_HTML).header("Content-Type", "text/html")
 }
-
-
 
 #[rupring::Get(path = /sse)]
 #[tags = [user]]


### PR DESCRIPTION
resolves: #274

## 설명
헤더 키에 대문자가 들어갔을 때의 단순 버그. 