### PR TITLE
[#292] fix: 쿠키 플래그 속성 직렬화 수정

### DIFF
--- a/rupring/src/response.rs
+++ b/rupring/src/response.rs
@@ -429,11 +429,15 @@ impl Response {
         }
 
         if let Some(secure) = cookie.secure {
-            cookie_str.push_str(&format!("; Secure={}", secure));
+            if secure {
+                cookie_str.push_str("; Secure");
+            }
         }
 
         if let Some(http_only) = cookie.http_only {
-            cookie_str.push_str(&format!("; HttpOnly={}", http_only));
+            if http_only {
+                cookie_str.push_str("; HttpOnly");
+            }
         }
 
         if let Some(same_site) = cookie.same_site {
@@ -569,4 +573,26 @@ impl Response {
 
 pub trait IntoResponse {
     fn into_response(self) -> Response;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::cookie::Cookie;
+
+    #[test]
+    fn add_cookie_serializes_secure_and_http_only_as_flag_attributes() {
+        let response =
+            Response::new().add_cookie(Cookie::new("session", "abc").secure(true).http_only(true));
+
+        let set_cookie = response
+            .headers
+            .get(&HeaderName::from_static(header::SET_COOKIE))
+            .expect("set-cookie header");
+
+        assert_eq!(
+            set_cookie,
+            &vec!["session=abc; Secure; HttpOnly".to_string()]
+        );
+    }
 }


### PR DESCRIPTION
resolves: #292

## 설명
- 표준 규격에 맞춰서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 쿠키의 보안 속성(`Secure`, `HttpOnly`)이 HTTP 표준 형식에 맞게 올바르게 직렬화되도록 수정되었습니다. 이제 이 속성들이 정확한 플래그 형식으로 `Set-Cookie` 헤더에 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->